### PR TITLE
 Remove clojerl as a dep in .app

### DIFF
--- a/src/test_check.app.src
+++ b/src/test_check.app.src
@@ -5,7 +5,6 @@
   , { applications
     , [ stdlib
       , kernel
-      , clojerl
       ]
     }
   ]


### PR DESCRIPTION
This is to be able to use test.check in clojerl's test.